### PR TITLE
Fix inheritance issue in InvokePolymorphicExpr causing ClassCastException

### DIFF
--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/Util.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/Util.java
@@ -99,6 +99,9 @@ public final class Util {
     }
 
     public static String toShortClassName(String desc) {
+        if (desc == null || desc.isEmpty()) {
+            return "";
+        }
         switch (desc.charAt(0)) {
         case 'Z':
             return "boolean";

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokeCustomExpr.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokeCustomExpr.java
@@ -4,7 +4,7 @@ import com.googlecode.d2j.MethodHandle;
 import com.googlecode.d2j.Proto;
 import com.googlecode.dex2jar.ir.LabelAndLocalMapper;
 
-public class InvokeCustomExpr extends AbstractInvokeExpr {
+public class InvokeCustomExpr extends InvokeExpr {
 
     public String name;
 
@@ -30,7 +30,7 @@ public class InvokeCustomExpr extends AbstractInvokeExpr {
 
     public InvokeCustomExpr(VT type, Value[] args, String methodName, Proto proto, MethodHandle handle,
                             Object[] bsmArgs) {
-        super(type, args);
+        super(type, args, handle == null ? null : handle.getMethod());
         this.proto = proto;
         this.name = methodName;
         this.handle = handle;
@@ -38,12 +38,12 @@ public class InvokeCustomExpr extends AbstractInvokeExpr {
     }
 
     @Override
-    public Value clone() {
+    public InvokeCustomExpr clone() {
         return new InvokeCustomExpr(vt, cloneOps(), name, proto, handle, bsmArgs);
     }
 
     @Override
-    public Value clone(LabelAndLocalMapper mapper) {
+    public InvokeCustomExpr clone(LabelAndLocalMapper mapper) {
         return new InvokeCustomExpr(vt, cloneOps(mapper), name, proto, handle, bsmArgs);
     }
 

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokeExpr.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokeExpr.java
@@ -30,13 +30,12 @@ public class InvokeExpr extends AbstractInvokeExpr {
 
     @Override
     public Proto getProto() {
-        return method.getProto();
+        return method == null ? null : method.getProto();
     }
 
     public InvokeExpr(VT type, Value[] args, String ownerType, String methodName, String[] argmentTypes,
                       String returnType) {
-        super(type, args);
-        this.method = new Method(ownerType, methodName, argmentTypes, returnType);
+        this(type, args, new Method(ownerType, methodName, argmentTypes, returnType));
     }
 
     public InvokeExpr(VT type, Value[] args, Method method) {
@@ -45,12 +44,12 @@ public class InvokeExpr extends AbstractInvokeExpr {
     }
 
     @Override
-    public Value clone() {
+    public InvokeExpr clone() {
         return new InvokeExpr(vt, cloneOps(), method);
     }
 
     @Override
-    public Value clone(LabelAndLocalMapper mapper) {
+    public InvokeExpr clone(LabelAndLocalMapper mapper) {
         return new InvokeExpr(vt, cloneOps(mapper), method);
     }
 
@@ -59,13 +58,13 @@ public class InvokeExpr extends AbstractInvokeExpr {
         StringBuilder sb = new StringBuilder();
 
         int i = 0;
-        if (super.vt == VT.INVOKE_NEW) {
-            sb.append("new ").append(Util.toShortClassName(method.getOwner()));
-        } else if (super.vt == VT.INVOKE_STATIC) {
-            sb.append(Util.toShortClassName(method.getOwner())).append('.')
-                    .append(this.method.getName());
+        if (vt == VT.INVOKE_NEW) {
+            sb.append("new ").append(Util.toShortClassName(getOwner()));
+        } else if (vt == VT.INVOKE_STATIC) {
+            sb.append(Util.toShortClassName(getOwner())).append('.')
+                    .append(getName());
         } else {
-            sb.append(ops[i++]).append('.').append(this.method.getName());
+            sb.append(ops[i++]).append('.').append(getName());
         }
         sb.append('(');
         boolean first = true;
@@ -82,19 +81,19 @@ public class InvokeExpr extends AbstractInvokeExpr {
     }
 
     public String getOwner() {
-        return method.getOwner();
+        return method == null ? null : method.getOwner();
     }
 
     public String getRet() {
-        return method.getReturnType();
+        return method == null ? null : method.getReturnType();
     }
 
     public String getName() {
-        return method.getName();
+        return method == null ? null : method.getName();
     }
 
     public String[] getArgs() {
-        return method.getParameterTypes();
+        return method == null ? null : method.getParameterTypes();
     }
 
 }

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokePolymorphicExpr.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokePolymorphicExpr.java
@@ -5,11 +5,9 @@ import com.googlecode.d2j.Proto;
 import com.googlecode.dex2jar.ir.LabelAndLocalMapper;
 import com.googlecode.dex2jar.ir.Util;
 
-public class InvokePolymorphicExpr extends AbstractInvokeExpr {
+public class InvokePolymorphicExpr extends InvokeExpr {
 
     public Proto proto;
-
-    public Method method;
 
     @Override
     protected void releaseMemory() {
@@ -24,9 +22,8 @@ public class InvokePolymorphicExpr extends AbstractInvokeExpr {
     }
 
     public InvokePolymorphicExpr(VT type, Value[] args, Proto proto, Method method) {
-        super(type, args);
+        super(type, args, method);
         this.proto = proto;
-        this.method = method;
     }
 
     @Override

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokePolymorphicExpr.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/expr/InvokePolymorphicExpr.java
@@ -11,7 +11,6 @@ public class InvokePolymorphicExpr extends InvokeExpr {
 
     @Override
     protected void releaseMemory() {
-        method = null;
         proto = null;
         super.releaseMemory();
     }
@@ -27,12 +26,12 @@ public class InvokePolymorphicExpr extends InvokeExpr {
     }
 
     @Override
-    public Value clone() {
+    public InvokePolymorphicExpr clone() {
         return new InvokePolymorphicExpr(vt, cloneOps(), proto, method);
     }
 
     @Override
-    public Value clone(LabelAndLocalMapper mapper) {
+    public InvokePolymorphicExpr clone(LabelAndLocalMapper mapper) {
         return new InvokePolymorphicExpr(vt, cloneOps(mapper), proto, method);
     }
 


### PR DESCRIPTION
`NewTransformer#findInvokeExpr` attempts to cast InvokePolymorphicExpr to `InvokeExpr` under certain inputs, which causes a ClassCastException. It appears that InvokePolymorphicExpr was meant to extend InvokeExpr for this reason?

I wonder if there may be other classes like `InvokeCustomExpr` that should be switched over to extend `InvokeExpr`

Fixes pxb1988/dex2jar#311. I experienced the same issue when attempting to use dex2jar against classes3.dex from framework.jar from official Android S emulator. Also realized I mixed up the commit name so I can redo and fix this pull request if needed.

Before:
<img width="1129" alt="Before" src="https://user-images.githubusercontent.com/25168557/132115570-1e28d7a2-8b04-421a-a3b1-8f7fd1676809.png">

After:
<img width="1126" alt="After" src="https://user-images.githubusercontent.com/25168557/132115573-dbdf9fab-2716-467f-b857-2b4262a5d6fe.png">