### PR TITLE
feat: Extract Hex class resource logic to a separate method

### DIFF
--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -566,7 +566,12 @@ public class Dex2Asm {
     }
 
     private void addHexDecodeMethod(ClassVisitor outCV, String className, String hexDecodeMethodNameBase) {
-        try (InputStream is = getHexClassAsStream()) {
+        InputStream hexClassStream = getHexClassAsStream();
+        if (hexClassStream == null) {
+            return;
+        }
+
+        try (InputStream is = hexClassStream) {
             ClassReader cr = new ClassReader(is);
             cr.accept(new ClassVisitor(Constants.ASM_VERSION) {
                 @Override

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -561,8 +561,12 @@ public class Dex2Asm {
     private static final Set<String> HEX_DECODE_METHODS =
             new HashSet<>(Arrays.asList("decode_J", "decode_I", "decode_S", "decode_B"));
 
+    protected InputStream getHexClassAsStream() {
+        return Dex2Asm.class.getResourceAsStream("/" + HEX_CLASS_LOCATION + ".class");
+    }
+
     private void addHexDecodeMethod(ClassVisitor outCV, String className, String hexDecodeMethodNameBase) {
-        try (InputStream is = Dex2Asm.class.getResourceAsStream("/" + HEX_CLASS_LOCATION + ".class")) {
+        try (InputStream is = getHexClassAsStream()) {
             ClassReader cr = new ClassReader(is);
             cr.accept(new ClassVisitor(Constants.ASM_VERSION) {
                 @Override


### PR DESCRIPTION
This PR extracts the `getResourceAsStream` call in `addHexDecodeMethod` to a separate, protected method so it can be overrided, and we can provide the Hex class from a different source.

The motive behind this is actually for my Android app [Dexter](https://github.com/MikeAndrson/Dexter/) in which I'm using D2J both as a standalone tool and a way to decompile Smali/DEX files using Java decompilers like Fernflower, CFR etc. But as you know, Android doesn't work with Java bytecode so something like `getResourceAsStream("/SomeClass.class")` to get the bytecode of a class in classpath simply doesn't work.

I thought of compiling `res/Hex.java` using `javac` and adding it to my APK's resources folder but unfortunately it doesn't work, the Android Gradle Plugin ignores all resources ending with ".class" when packaging so that's out the window. However with this PR I can simply override `getHexClassAsStream` and provide the class from wherever I want. 

I actually did that with my fork right here (provided it from my app's assets): https://github.com/MikeAndrson/Dexter/blob/b94f8a405ba69b428cd156f0bf86b0d2e201c23e/app/src/main/kotlin/ma/dexter/tools/d2j/D2JFacade.kt#L97

If you feel that this isn't the best fix for this, I'm open to ideas 👍