### PR TITLE
Outline for Asm2Dex plus supporting Dex2Dx util

### DIFF
--- a/dex-reader-api/src/main/java/com/googlecode/d2j/Field.java
+++ b/dex-reader-api/src/main/java/com/googlecode/d2j/Field.java
@@ -11,17 +11,17 @@ public class Field {
     /**
      * name of the field.
      */
-    private String name;
+    private final String name;
 
     /**
      * owner of the field, in TypeDescriptor format.
      */
-    private String owner;
+    private final String owner;
 
     /**
      * type of the field, in TypeDescriptor format.
      */
-    private String type;
+    private final String type;
 
     public Field(String owner, String name, String type) {
         this.owner = owner;

--- a/dex-reader-api/src/main/java/com/googlecode/d2j/node/DexFieldNode.java
+++ b/dex-reader-api/src/main/java/com/googlecode/d2j/node/DexFieldNode.java
@@ -5,6 +5,8 @@ import com.googlecode.d2j.Visibility;
 import com.googlecode.d2j.visitors.DexAnnotationVisitor;
 import com.googlecode.d2j.visitors.DexClassVisitor;
 import com.googlecode.d2j.visitors.DexFieldVisitor;
+import org.objectweb.asm.Opcodes;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +35,10 @@ public class DexFieldNode extends DexFieldVisitor {
         this.access = access;
         this.field = field;
         this.cst = cst;
+    }
+
+    public boolean isStatic() {
+        return (access & Opcodes.ACC_STATIC) != 0;
     }
 
     public void accept(DexClassVisitor dcv) {

--- a/dex-reader-api/src/main/java/com/googlecode/d2j/node/DexMethodNode.java
+++ b/dex-reader-api/src/main/java/com/googlecode/d2j/node/DexMethodNode.java
@@ -7,6 +7,8 @@ import com.googlecode.d2j.visitors.DexAnnotationVisitor;
 import com.googlecode.d2j.visitors.DexClassVisitor;
 import com.googlecode.d2j.visitors.DexCodeVisitor;
 import com.googlecode.d2j.visitors.DexMethodVisitor;
+import org.objectweb.asm.Opcodes;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +34,22 @@ public class DexMethodNode extends DexMethodVisitor {
         super();
         this.access = access;
         this.method = method;
+    }
+
+    public boolean isStatic() {
+        return (access & Opcodes.ACC_STATIC) != 0;
+    }
+
+    public boolean isPrivate() {
+        return (access & Opcodes.ACC_PRIVATE) != 0;
+    }
+
+    public boolean isConstructor() {
+        return method.getName().equals("<init>");
+    }
+
+    public boolean isStaticInitializer() {
+        return method.getName().equals("<clinit>");
     }
 
     public void accept(DexClassVisitor dcv) {
@@ -110,5 +128,4 @@ public class DexMethodNode extends DexMethodVisitor {
             return annotation;
         };
     }
-
 }

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Asm2Dex.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Asm2Dex.java
@@ -1,0 +1,171 @@
+package com.googlecode.d2j.dex;
+
+import com.android.dx.cf.direct.DirectClassFile;
+import com.android.dx.cf.direct.StdAttributeFactory;
+import com.android.dx.cf.iface.ParseException;
+import com.android.dx.cf.iface.ParseObserver;
+import com.android.dx.command.dexer.DxContext;
+import com.android.dx.dex.DexOptions;
+import com.android.dx.dex.cf.CfOptions;
+import com.android.dx.dex.cf.CfTranslator;
+import com.android.dx.dex.file.ClassDefItem;
+import com.android.dx.dex.file.DexFile;
+import com.googlecode.d2j.DexConstants;
+import com.googlecode.d2j.node.DexClassNode;
+import com.googlecode.d2j.node.DexFileNode;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class Asm2Dex {
+	private final Map<String, byte[]> classes = new HashMap<>();
+	private Function<ClassNode, byte[]> asmNodeToBytes = n -> {
+		// We will assume class has already computed maxs/frames.
+		// If not the user can provide an override mapping function.
+		ClassWriter cw = new ClassWriter(0);
+		n.accept(cw);
+		return cw.toByteArray();
+	};
+	private Function<DexClassNode, byte[]> dexNodeToBytes = n -> {
+		// Ideally we can get rid of this, since converting to Java to then
+		// convert back to dex is silly.
+		Dex2Asm dex2Asm = new Dex2Asm();
+		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+		dex2Asm.convertClass(n, classInternalName -> cw);
+		return cw.toByteArray();
+	};
+	private Supplier<DexFileNode> dexFileProvider = DexFileNode::new;
+	private boolean dxStrictNameCheck = false;
+	private boolean dxIncludeLocalInfo = false;
+	private boolean dxOptimize = false;
+	private boolean dxWriteVerbose = false;
+	private Writer dxWriterOutput = null;
+	private ParseObserver dxParseObserver = null;
+
+	public Asm2Dex setDxStrictNameCheck(boolean dxStrictNameCheck) {
+		this.dxStrictNameCheck = dxStrictNameCheck;
+		return this;
+	}
+
+	public Asm2Dex setDxIncludeLocalInfo(boolean dxIncludeLocalInfo) {
+		this.dxIncludeLocalInfo = dxIncludeLocalInfo;
+		return this;
+	}
+
+	public Asm2Dex setDxOptimize(boolean dxOptimize) {
+		this.dxOptimize = dxOptimize;
+		return this;
+	}
+
+	public Asm2Dex setDxWriteVerbose(boolean dxWriteVerbose) {
+		this.dxWriteVerbose = dxWriteVerbose;
+		return this;
+	}
+
+	public Asm2Dex setDxWriterOutput(Writer dxWriterOutput) {
+		this.dxWriterOutput = dxWriterOutput;
+		return this;
+	}
+
+	public Asm2Dex setDxParseObserver(ParseObserver dxParseObserver) {
+		this.dxParseObserver = dxParseObserver;
+		return this;
+	}
+
+	public Asm2Dex setDexFileProvider(Supplier<DexFileNode> dexFileProvider) {
+		this.dexFileProvider = dexFileProvider;
+		return this;
+	}
+
+	public Asm2Dex setAsmNodeToBytes(Function<ClassNode, byte[]> asmNodeToBytes) {
+		this.asmNodeToBytes = asmNodeToBytes;
+		return this;
+	}
+
+	public Asm2Dex setDexNodeToBytes(Function<DexClassNode, byte[]> dexNodeToBytes) {
+		this.dexNodeToBytes = dexNodeToBytes;
+		return this;
+	}
+
+	public Asm2Dex addJvmClass(String internalName, byte[] clz) {
+		classes.put(internalName, clz);
+		return this;
+	}
+
+	public Asm2Dex addJvmClasses(Map<String, byte[]> clzMap) {
+		classes.putAll(clzMap);
+		return this;
+	}
+
+	public Asm2Dex addJvmClassNode(String internalName, ClassNode clz) {
+		classes.put(internalName, asmNodeToBytes.apply(clz));
+		return this;
+	}
+
+	public Asm2Dex addJvmClassNodes(Map<String, ClassNode> clzMap) {
+		Map<String, byte[]> mapped = clzMap.entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, e -> asmNodeToBytes.apply(e.getValue())));
+		addJvmClasses(mapped);
+		return this;
+	}
+
+	public byte[] buildDexFile() throws ParseException, IOException {
+		DexFileNode dexFileNode = dexFileProvider.get();
+
+		// Use DX to create a dex file
+		CfOptions cfOptions = new CfOptions();
+		cfOptions.strictNameCheck = dxStrictNameCheck;
+		cfOptions.localInfo = dxIncludeLocalInfo;
+		cfOptions.optimize = dxOptimize;
+		DexOptions dexOptions = new DexOptions();
+		if (dexFileNode != null && dexFileNode.dexVersion >= DexConstants.DEX_037) {
+			dexOptions.minSdkVersion = 26;
+		}
+		DexFile dxFileOutput = new DexFile(dexOptions);
+
+
+		DxContext context = new DxContext();
+		BiConsumer<String, byte[]> javaDexInputConsumer = (className, classBytes) -> {
+			DirectClassFile dcf = new DirectClassFile(classBytes, className + ".class", true);
+			dcf.setAttributeFactory(new StdAttributeFactory());
+			dcf.setObserver(dxParseObserver);
+
+			// Translate to dalvik
+			ClassDefItem item = CfTranslator.translate(context, dcf, classBytes, cfOptions, dexOptions, dxFileOutput);
+
+			// TODO: Is this process needed, does translate do it for us?
+			dxFileOutput.add(item);
+		};
+
+		// Add class file entries
+		for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
+			String className = entry.getKey();
+			byte[] classBytes = entry.getValue();
+			javaDexInputConsumer.accept(className, classBytes);
+		}
+
+		// Add our existing DexClassNode's entries
+		if (dexFileNode != null && !dexFileNode.clzs.isEmpty()) {
+			for (DexClassNode clz : dexFileNode.clzs) {
+				// TODO: Ideally we do not have to convert DEX to Java before back into DEX
+				//       We need to map our DexClassNode into an input that can be consumed here.
+				//         Replace with one-liner: Dex2DxDef.appendToDexFile(dxFileOutput, clz);
+				String className = clz.className.substring(1, clz.className.length() - 1);
+				byte[] classBytes = dexNodeToBytes.apply(clz);
+				javaDexInputConsumer.accept(className, classBytes);
+			}
+		}
+
+		byte[] dxBytes = dxFileOutput.toDex(dxWriterOutput, dxWriteVerbose);
+		return dxBytes;
+	}
+}

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2DxDef.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2DxDef.java
@@ -1,0 +1,92 @@
+package com.googlecode.d2j.dex;
+
+import com.android.dx.dex.code.DalvCode;
+import com.android.dx.dex.file.ClassDefItem;
+import com.android.dx.dex.file.DexFile;
+import com.android.dx.dex.file.EncodedField;
+import com.android.dx.dex.file.EncodedMethod;
+import com.android.dx.rop.annotation.Annotation;
+import com.android.dx.rop.annotation.AnnotationVisibility;
+import com.android.dx.rop.annotation.Annotations;
+import com.android.dx.rop.cst.*;
+import com.android.dx.rop.type.StdTypeList;
+import com.android.dx.rop.type.Type;
+import com.googlecode.d2j.node.DexAnnotationNode;
+import com.googlecode.d2j.node.DexClassNode;
+import com.googlecode.d2j.node.DexFieldNode;
+import com.googlecode.d2j.node.DexMethodNode;
+
+public class Dex2DxDef {
+	public static ClassDefItem appendToDexFile(DexFile dexFile, DexClassNode classNode) {
+		int flags = classNode.access;
+		CstType thisClass = CstType.intern(Type.intern(classNode.className));
+		CstType superClass = classNode.superClass == null ? null : CstType.intern(Type.intern(classNode.superClass));
+		StdTypeList interfaces = new StdTypeList(classNode.interfaceNames.length);
+		for (int i = 0; i < classNode.interfaceNames.length; i++) {
+			Type interfaceType = Type.intern(classNode.interfaceNames[i]);
+			interfaces.set(i, interfaceType);
+		}
+		CstString sourceFile = classNode.source == null ? null : new CstString(classNode.source);
+		ClassDefItem classDef = new ClassDefItem(thisClass, flags, superClass, interfaces, sourceFile);
+
+		for (DexFieldNode field : classNode.fields) {
+			CstNat fieldNameType = new CstNat(new CstString(field.field.getName()), new CstString(field.field.getType()));
+			CstFieldRef fieldRef = new CstFieldRef(thisClass, fieldNameType);
+			EncodedField encodedField = new EncodedField(fieldRef, field.access);
+
+			if (!field.anns.isEmpty()) {
+				Annotations annotations = new Annotations();
+				// TODO: Want to handle annotations that are system ones (which we pull out into fields)
+				//    AND 3rd party annotations which always stay in the 'anns' list
+				for (DexAnnotationNode ann : field.anns) {
+					CstType annType = CstType.intern(Type.intern(ann.type));
+					AnnotationVisibility visibility = AnnotationVisibility.values()[ann.visibility.ordinal()];
+					annotations.add(new Annotation(annType, visibility));
+				}
+				if (annotations.size() > 0)
+					classDef.addFieldAnnotations(fieldRef, annotations, dexFile);
+			}
+
+			if (field.isStatic()) {
+				// TODO: Need a way to easily know the cst type, and map to appropriate CstX type
+				Constant constant = null;
+				classDef.addStaticField(encodedField, constant);
+			} else {
+				classDef.addInstanceField(encodedField);
+			}
+		}
+
+		for (DexMethodNode method : classNode.methods) {
+			CstNat methodNameType = new CstNat(new CstString(method.method.getName()), new CstString(method.method.getDesc()));
+			CstMethodRef methodRef = new CstMethodRef(thisClass, methodNameType);
+			StdTypeList throwsList = new StdTypeList(0); // TODO: Need to extract throws annotation to write this back
+			DalvCode code = null; // TODO: This is gonna be a lot of work
+			EncodedMethod encodedMethod = new EncodedMethod(methodRef, method.access, code, throwsList);
+
+			if (!method.anns.isEmpty()) {
+				Annotations annotations = new Annotations();
+				// TODO: Want to handle annotations that are system ones (which we pull out into fields)
+				//    AND 3rd party annotations which always stay in the 'anns' list
+				for (DexAnnotationNode ann : method.anns) {
+					CstType annType = CstType.intern(Type.intern(ann.type));
+					AnnotationVisibility visibility = AnnotationVisibility.values()[ann.visibility.ordinal()];
+					annotations.add(new Annotation(annType, visibility));
+				}
+
+				if (annotations.size() > 0)
+					classDef.addMethodAnnotations(methodRef, annotations, dexFile);
+
+				// TODO: When to use: addParameterAnnotations(...) ???
+			}
+
+			if (method.isStatic() || method.isPrivate() || method.isConstructor() || method.isStaticInitializer()) {
+				classDef.addDirectMethod(encodedMethod);
+			} else {
+				classDef.addVirtualMethod(encodedMethod);
+			}
+		}
+
+		classDef.addContents(dexFile);
+		return classDef;
+	}
+}


### PR DESCRIPTION
The rough idea for supporting Asm2Dex and Dex2Dx logic.

The plan is to rework the base types to be more flexible, with features to address TODO comments mentioned here. Then once done, re-approach the work explored here.

Some changes would include:

- Reworking the Node types to be less bare-bones
    - Raw field access to the bare minimum is not ideal
    - System annotations need to be easily accessed by end users (like in #35), but easily iterated over as the original annotation as noted in the `Dex2DxDef` logic shown here.
- Reduce duplicate code
- Move to newer D8 since DX [is being deprecated](https://android-developers.googleblog.com/2018/04/android-studio-switching-to-d8-dexer.html)
    - Re-use parsing logic where possible from D8 from public API classes to reduce space for bugs in the `dex2jar` code-space
    - If we need to build D8 ourselves to bypass the proguard naming on their public releases, we should maintain a fork somewhere and look into building the jars ourselves

This PR is not meant to be merged, just as a preview and discussion