### PR TITLE
fix string length being in utf-16

### DIFF
--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
@@ -138,8 +138,9 @@ public final class Dex2jar {
                         }
                         try {
                             if (baos != null) {
-                                baos.write(ByteBuffer.allocate(4).putInt(className.length()).array());
-                                baos.write(className.getBytes(StandardCharsets.UTF_8));
+                                byte[] classNameBytes = className.getBytes(StandardCharsets.UTF_8);
+                                baos.write(ByteBuffer.allocate(4).putInt(classNameBytes.length).array());
+                                baos.write(classNameBytes);
                                 baos.write(ByteBuffer.allocate(4).putInt(data.length).array());
                                 baos.write(data);
                             }


### PR DESCRIPTION
the length of the string was encoded in utf-16, but the string was encoded in utf8, so if there were any codes outside of ascii, the length wouldn't match the byte length.

this fixes that by actually using the length of the byte array.