### PR TITLE
Correctly propagate dex version in MultiDexFileReader

### DIFF
--- a/dex-reader/src/main/java/com/googlecode/d2j/reader/MultiDexFileReader.java
+++ b/dex-reader/src/main/java/com/googlecode/d2j/reader/MultiDexFileReader.java
@@ -110,6 +110,7 @@ public class MultiDexFileReader implements BaseDexFileReader {
 
     @Override
     public void accept(DexFileVisitor dv, int config) {
+        dv.visitDexFileVersion(getDexVersion());
         int size = items.size();
         for (int i = 0; i < size; i++) {
             accept(dv, i, config);


### PR DESCRIPTION
When using dex2jar on an apk (zip) file, the dexVersion is not properly propagated resulting in the classes in the output jar having the incorrect java bytecode version (e.g. 50) instead of the correct version based on the input dex (e.g. 52). This can result in errors building against the output jar if the classes contain features not actually valid in that version.

To demonstrate, take a modern apk and run d2j-dex2jar.sh first with the apk file, and again against the extracted classes.dex. The resulting jar file from the former will *always* contain classes of version 50 (1.6). The latter should correctly use the version corresponding to the dex version (e.g. 52).