### PR TITLE
fixed type merge fails when type class is combination of int and boolean

### DIFF
--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/TypeTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/TypeTransformer.java
@@ -494,6 +494,10 @@ public class TypeTransformer implements Transformer {
                 } else if (!ta.fixed && tb.fixed) {
                     return b;
                 } else if (ta.fixed) {
+                    if ((ta == TypeClass.INT && tb == TypeClass.BOOLEAN)
+                            || (tb == TypeClass.INT && ta == TypeClass.BOOLEAN)) {
+                        return buildArray(as, "I");
+                    }
                     if (ta != tb) {
                         return buildArray(as == 0 ? 0 : as - 1, "L");
                     }


### PR DESCRIPTION
In the current `TypeTransformer` code, `mergeTypeEx` fails to merge when ta and tb are a combination of `int` and `boolean`.

The failure stems from the following:

- Integer and Boolean types are passed as parameters.

- Both have an array dimension of 0 and are treated as fixed types.

- As a result, buildArray is invoked and—given the parameter conditions (dimension = 0, type(s) = "L")—it always returns "L".

Following this flow, a value is returned that has not been correctly merged.

During Dex → Jar conversion, mixed `boolean` / `int` types must be distinguished. An example of this distinction is implemented in `mergeProviderType`.

> In Java, `boolean` and `int` are considered the same type category, whereas in Dalvik a `boolean` is internally represented as an `int`.

However, mergeTypeEx does not implement the above exception handling. I’m submitting a PR with a commit that adds this exception logic.

ps. You can test this issue with Pinterest service apk, I'll send you one if you need it :).