### PR TITLE
New: Invoke correct constructor during optimization

### DIFF
--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
@@ -155,7 +155,7 @@ public class NewTransformer implements Transformer {
             InvokeExpr ie = findInvokeExpr(obj.invokeStmt);
             Value[] orgOps = ie.getOps();
             Value[] nOps = Arrays.copyOfRange(orgOps, 1, orgOps.length);
-            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ie.getOwner());
+            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ((NewExpr) obj.init.getOp2()).type);
             method.stmts.replace(obj.invokeStmt, Stmts.nAssign(obj.local, invokeNew));
         }
     }

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
@@ -155,7 +155,7 @@ public class NewTransformer implements Transformer {
             InvokeExpr ie = findInvokeExpr(obj.invokeStmt);
             Value[] orgOps = ie.getOps();
             Value[] nOps = Arrays.copyOfRange(orgOps, 1, orgOps.length);
-            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ((NewExpr) obj.init.getOp2()).type);
+            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ie.getOwner());
             method.stmts.replace(obj.invokeStmt, Stmts.nAssign(obj.local, invokeNew));
         }
     }
@@ -344,6 +344,8 @@ public class NewTransformer implements Transformer {
                 keep = false;
             }
             if (obj.invokeStmt == null) {
+                keep = false;
+            } else if (!findInvokeExpr(obj.invokeStmt).getOwner().equals(((NewExpr) obj.init.getOp2()).type)) {
                 keep = false;
             }
             if (!keep) {


### PR DESCRIPTION
We may have byte code like this:

```
006a5c: 2200 2900                              |0000: new-instance v0, LTestClass; // type@0029
006a60: 1a01 2803                              |0002: const-string v1, "en" // string@0328
006a64: 7030 5900 1001                         |0004: invoke-direct {v0, v1, v1}, LTestBase;.<init>:(Ljava/lang/String;Ljava/lang/String;)V // method@0059
```

Previously, this was translated to a call to `new TestBase("en", "en")`, instead of `new TestClass("en", "en")` (where `TestClass extends TestBase`).

Ref: keiyoushi/extensions-source#15400, Suwayomi/Suwayomi-Server#1964