### PR TITLE
New: Invoke correct constructor during optimization

### DIFF
--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/ConstructorGenerator.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/ConstructorGenerator.java
@@ -9,7 +9,27 @@ import java.util.concurrent.ConcurrentHashMap;
  * Used to manage all additional constructors that need to be generated during IR transformation
  */
 public class ConstructorGenerator {
+
+    private final Map<ConstructorPair, String> constructors = new ConcurrentHashMap<>();
+
+    public void add(String owner, String[] parameterTypes, String baseOwner) {
+        ConstructorPair index = new ConstructorPair(owner, parameterTypes);
+        String oldValue = constructors.put(index, baseOwner);
+        if (oldValue != null && !oldValue.equals(baseOwner)) {
+            throw new ConstructorMismatchException(oldValue, baseOwner);
+        }
+    }
+
+    public boolean isEmpty() {
+        return constructors.isEmpty();
+    }
+
+    public Iterable<Map.Entry<ConstructorPair, String>> entries() {
+        return constructors.entrySet();
+    }
+
     public static final class ConstructorPair {
+
         private final String owner;
         private final String[] parameterTypes;
 
@@ -38,14 +58,17 @@ public class ConstructorGenerator {
         public int hashCode() {
             return Objects.hash(owner, Arrays.hashCode(parameterTypes));
         }
+
     }
 
     public static final class ConstructorMismatchException extends RuntimeException {
+
         private final String oldBase;
         private final String newBase;
 
         public ConstructorMismatchException(String oldBase, String newBase) {
-            super(String.format("Internal error: Mismatch in constructor types, expected base class %s, but got %s", oldBase, newBase));
+            super(String.format("Internal error: Mismatch in constructor types, expected base class %s, but got %s",
+                    oldBase, newBase));
             this.oldBase = oldBase;
             this.newBase = newBase;
         }
@@ -57,23 +80,7 @@ public class ConstructorGenerator {
         public String getNewBase() {
             return newBase;
         }
+
     }
 
-    private final Map<ConstructorPair, String> constructors = new ConcurrentHashMap<>();
-
-    public void Add(String owner, String[] parameterTypes, String baseOwner) {
-        ConstructorPair index = new ConstructorPair(owner, parameterTypes);
-        String oldValue = constructors.put(index, baseOwner);
-        if (oldValue != null && !oldValue.equals(baseOwner)) {
-            throw new ConstructorMismatchException(oldValue, baseOwner);
-        }
-    }
-
-    public boolean isEmpty() {
-        return constructors.isEmpty();
-    }
-
-    public Iterable<Map.Entry<ConstructorPair, String>> entries() {
-        return constructors.entrySet();
-    }
 }

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/ConstructorGenerator.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/ConstructorGenerator.java
@@ -1,0 +1,79 @@
+package com.googlecode.dex2jar.ir.ts;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Used to manage all additional constructors that need to be generated during IR transformation
+ */
+public class ConstructorGenerator {
+    public static final class ConstructorPair {
+        private final String owner;
+        private final String[] parameterTypes;
+
+        public ConstructorPair(String owner, String[] parameterTypes) {
+            this.owner = owner;
+            this.parameterTypes = parameterTypes;
+        }
+
+        public String getOwner() {
+            return owner;
+        }
+
+        public String[] getParameterTypes() {
+            return parameterTypes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ConstructorPair)) return false;
+            ConstructorPair that = (ConstructorPair) o;
+            return Objects.equals(owner, that.owner) && Objects.deepEquals(parameterTypes, that.parameterTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(owner, Arrays.hashCode(parameterTypes));
+        }
+    }
+
+    public static final class ConstructorMismatchException extends RuntimeException {
+        private final String oldBase;
+        private final String newBase;
+
+        public ConstructorMismatchException(String oldBase, String newBase) {
+            super(String.format("Internal error: Mismatch in constructor types, expected base class %s, but got %s", oldBase, newBase));
+            this.oldBase = oldBase;
+            this.newBase = newBase;
+        }
+
+        public String getOldBase() {
+            return oldBase;
+        }
+
+        public String getNewBase() {
+            return newBase;
+        }
+    }
+
+    private final Map<ConstructorPair, String> constructors = new ConcurrentHashMap<>();
+
+    public void Add(String owner, String[] parameterTypes, String baseOwner) {
+        ConstructorPair index = new ConstructorPair(owner, parameterTypes);
+        String oldValue = constructors.put(index, baseOwner);
+        if (oldValue != null && !oldValue.equals(baseOwner)) {
+            throw new ConstructorMismatchException(oldValue, baseOwner);
+        }
+    }
+
+    public boolean isEmpty() {
+        return constructors.isEmpty();
+    }
+
+    public Iterable<Map.Entry<ConstructorPair, String>> entries() {
+        return constructors.entrySet();
+    }
+}

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/ConstructorGenerator.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/ConstructorGenerator.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ConstructorGenerator {
 
     private final Map<ConstructorPair, String> constructors = new ConcurrentHashMap<>();
+    private String currentParentClass;
 
     public void add(String owner, String[] parameterTypes, String baseOwner) {
         ConstructorPair index = new ConstructorPair(owner, parameterTypes);
@@ -22,6 +23,19 @@ public class ConstructorGenerator {
 
     public boolean isEmpty() {
         return constructors.isEmpty();
+    }
+
+    public void enterClass(String owner, String baseOwner) {
+        if (currentParentClass != null) throw new IllegalStateException("Enter called without reset, recursion is not implemented");
+        currentParentClass = baseOwner;
+    }
+
+    public void leaveClass() {
+        currentParentClass = null;
+    }
+
+    public String getCurrentParentClass() {
+        return currentParentClass;
     }
 
     public Iterable<Map.Entry<ConstructorPair, String>> entries() {

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
@@ -155,7 +155,7 @@ public class NewTransformer implements Transformer {
             InvokeExpr ie = findInvokeExpr(obj.invokeStmt);
             Value[] orgOps = ie.getOps();
             Value[] nOps = Arrays.copyOfRange(orgOps, 1, orgOps.length);
-            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ie.getOwner());
+            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ((NewExpr) obj.init.getOp2()).type);
             method.stmts.replace(obj.invokeStmt, Stmts.nAssign(obj.local, invokeNew));
         }
     }

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
@@ -63,7 +63,13 @@ public class NewTransformer implements Transformer {
         // a=new Abc();
         // b=a;
         // =========
+        // also fixup calls to <init> to use correct class, since Dex allows invoke-special on parent class
         replaceX(method, constructorGenerator);
+
+        // 1a. fixup super constructor calls, similar to new calls in replaceX
+        if ("<init>".equals(method.name) && constructorGenerator != null) {
+            replaceSuper(method, constructorGenerator);
+        }
 
         // 2. replace NEW Abc;.<init>() -> new Abc();
         replaceAST(method);
@@ -85,6 +91,27 @@ public class NewTransformer implements Transformer {
             if (!init.isEmpty()) {
                 replace0(method, init, size, constructorGenerator);
             }
+            for (Stmt stmt : method.stmts) {
+                stmt.frame = null;
+            }
+        }
+    }
+
+    void replaceSuper(IrMethod method, ConstructorGenerator constructorGenerator) {
+        final HashMap<InvokeExpr, Stmt> init = new HashMap<>();
+        for (Stmt p : method.stmts) {
+            if (p.st == VOID_INVOKE && p.getOp().vt == INVOKE_SPECIAL) {
+                // the stmt is a new assign stmt
+                InvokeExpr local = (InvokeExpr) p.getOp();
+                if ("<init>".equals(local.method.getName()) && !Objects.equals(constructorGenerator.getCurrentParentClass(), local.getOwner())) {
+                    init.put(local, p);
+                }
+            }
+        }
+
+        if (!init.isEmpty()) {
+            final int size = Cfg.reIndexLocal(method);
+            replace1(method, init, size, constructorGenerator);
             for (Stmt stmt : method.stmts) {
                 stmt.frame = null;
             }
@@ -168,6 +195,17 @@ public class NewTransformer implements Transformer {
                 constructorGenerator.add(thisType, ie.getArgs(), ie.getOwner());
             }
             method.stmts.replace(obj.invokeStmt, Stmts.nAssign(obj.local, invokeNew));
+        }
+    }
+
+    void replace1(IrMethod method, Map<InvokeExpr, Stmt> init, int size, ConstructorGenerator constructorGenerator) {
+        for (Map.Entry<InvokeExpr, Stmt> obj : init.entrySet()) {
+            Stmt p = obj.getValue();
+            InvokeExpr ie = obj.getKey();
+            InvokeExpr invokeSuperFixed = Exprs.nInvokeSpecial(ie.getOps(), constructorGenerator.getCurrentParentClass(),
+                    ie.getName(), ie.getArgs(), ie.getRet());
+            p.setOp(invokeSuperFixed);
+            constructorGenerator.add(constructorGenerator.getCurrentParentClass(), ie.getArgs(), ie.getOwner());
         }
     }
 

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
@@ -12,13 +12,8 @@ import com.googlecode.dex2jar.ir.stmt.AssignStmt;
 import com.googlecode.dex2jar.ir.stmt.LabelStmt;
 import com.googlecode.dex2jar.ir.stmt.Stmt;
 import com.googlecode.dex2jar.ir.stmt.Stmts;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 
 import static com.googlecode.dex2jar.ir.expr.Value.VT.INVOKE_SPECIAL;
 import static com.googlecode.dex2jar.ir.expr.Value.VT.LOCAL;
@@ -49,7 +44,10 @@ public class NewTransformer implements Transformer {
 
     @Override
     public void transform(IrMethod method) {
+        transform(method, null);
+    }
 
+    public void transform(IrMethod method, ConstructorGenerator constructorGenerator) {
         // 1. replace
         // =========
         // a=NEW Abc;
@@ -59,14 +57,13 @@ public class NewTransformer implements Transformer {
         // a=new Abc();
         // b=a;
         // =========
-        replaceX(method);
+        replaceX(method, constructorGenerator);
 
         // 2. replace NEW Abc;.<init>() -> new Abc();
         replaceAST(method);
-
     }
 
-    void replaceX(IrMethod method) {
+    void replaceX(IrMethod method, ConstructorGenerator constructorGenerator) {
         final Map<Local, TObject> init = new HashMap<>();
         for (Stmt p : method.stmts) {
             if (p.st == ASSIGN && p.getOp1().vt == LOCAL && p.getOp2().vt == NEW) {
@@ -80,7 +77,7 @@ public class NewTransformer implements Transformer {
             final int size = Cfg.reIndexLocal(method);
             makeSureUsedBeforeConstructor(method, init, size);
             if (!init.isEmpty()) {
-                replace0(method, init, size);
+                replace0(method, init, size, constructorGenerator);
             }
             for (Stmt stmt : method.stmts) {
                 stmt.frame = null;
@@ -112,7 +109,7 @@ public class NewTransformer implements Transformer {
         }
     }
 
-    void replace0(IrMethod method, Map<Local, TObject> init, int size) {
+    void replace0(IrMethod method, Map<Local, TObject> init, int size, ConstructorGenerator constructorGenerator) {
         Set<Local> toDelete = new HashSet<>();
 
         Local[] locals = new Local[size];
@@ -155,7 +152,14 @@ public class NewTransformer implements Transformer {
             InvokeExpr ie = findInvokeExpr(obj.invokeStmt);
             Value[] orgOps = ie.getOps();
             Value[] nOps = Arrays.copyOfRange(orgOps, 1, orgOps.length);
-            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), ((NewExpr) obj.init.getOp2()).type);
+            String thisType = ((NewExpr) obj.init.getOp2()).type;
+            InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), thisType);
+            if (!Objects.equals(thisType, ie.getOwner())) {
+                if (constructorGenerator == null) {
+                    throw new RuntimeException("No ConstructorGenerator supplied but required for correct transformation");
+                }
+                constructorGenerator.Add(thisType, ie.getArgs(), ie.getOwner());
+            }
             method.stmts.replace(obj.invokeStmt, Stmts.nAssign(obj.local, invokeNew));
         }
     }

--- a/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
+++ b/dex-ir/src/main/java/com/googlecode/dex2jar/ir/ts/NewTransformer.java
@@ -12,8 +12,14 @@ import com.googlecode.dex2jar.ir.stmt.AssignStmt;
 import com.googlecode.dex2jar.ir.stmt.LabelStmt;
 import com.googlecode.dex2jar.ir.stmt.Stmt;
 import com.googlecode.dex2jar.ir.stmt.Stmts;
-
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import static com.googlecode.dex2jar.ir.expr.Value.VT.INVOKE_SPECIAL;
 import static com.googlecode.dex2jar.ir.expr.Value.VT.LOCAL;
@@ -156,9 +162,10 @@ public class NewTransformer implements Transformer {
             InvokeExpr invokeNew = Exprs.nInvokeNew(nOps, ie.getArgs(), thisType);
             if (!Objects.equals(thisType, ie.getOwner())) {
                 if (constructorGenerator == null) {
-                    throw new RuntimeException("No ConstructorGenerator supplied but required for correct transformation");
+                    throw new RuntimeException("No ConstructorGenerator supplied but required for correct " +
+                                               "transformation");
                 }
-                constructorGenerator.Add(thisType, ie.getArgs(), ie.getOwner());
+                constructorGenerator.add(thisType, ie.getArgs(), ie.getOwner());
             }
             method.stmts.replace(obj.invokeStmt, Stmts.nAssign(obj.local, invokeNew));
         }

--- a/dex-tools/src/main/java/com/googlecode/dex2jar/tools/Dex2jarMultiThreadCmd.java
+++ b/dex-tools/src/main/java/com/googlecode/dex2jar/tools/Dex2jarMultiThreadCmd.java
@@ -14,16 +14,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
+
+import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
@@ -132,8 +126,10 @@ public class Dex2jarMultiThreadCmd extends BaseCmd {
                 if (fileNode.clzs != null) {
                     final Map<String, Clz> classes = collectClzInfo(fileNode);
                     final List<Future<?>> results = new ArrayList<>(fileNode.clzs.size());
+                    final Map<String, ClassVisitor> classVisitors = new ConcurrentHashMap<>(classes.size());
+                    final ConstructorGenerator constructorGenerator = new ConstructorGenerator();
                     for (final DexClassNode classNode : fileNode.clzs) {
-                        results.add(executorService.submit(() -> convertClass(fileNode, classNode, cvf, classes)));
+                        results.add(executorService.submit(() -> classVisitors.put(classNode.className, convertClass(fileNode, classNode, cvf, classes, constructorGenerator))));
                     }
                     executorService.submit(() -> {
                         for (Future<?> result : results) {
@@ -143,6 +139,15 @@ public class Dex2jarMultiThreadCmd extends BaseCmd {
                                 e.printStackTrace();
                             }
                         }
+
+                        if (!constructorGenerator.isEmpty()) {
+                            insertConstructors(fileNode.clzs, classVisitors, constructorGenerator);
+                        }
+
+                        for (ClassVisitor cv : classVisitors.values()) {
+                            cv.visitEnd();
+                        }
+
                         BaksmaliBaseDexExceptionHandler exceptionHandler1 =
                                 (BaksmaliBaseDexExceptionHandler) exceptionHandler;
                         if (exceptionHandler1.hasException()) {

--- a/dex-tools/src/main/java/com/googlecode/dex2jar/tools/Dex2jarMultiThreadCmd.java
+++ b/dex-tools/src/main/java/com/googlecode/dex2jar/tools/Dex2jarMultiThreadCmd.java
@@ -8,16 +8,24 @@ import com.googlecode.d2j.node.DexFileNode;
 import com.googlecode.d2j.reader.BaseDexFileReader;
 import com.googlecode.d2j.reader.DexFileReader;
 import com.googlecode.d2j.reader.MultiDexFileReader;
+import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
-import java.util.concurrent.*;
-
-import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
@@ -129,7 +137,8 @@ public class Dex2jarMultiThreadCmd extends BaseCmd {
                     final Map<String, ClassVisitor> classVisitors = new ConcurrentHashMap<>(classes.size());
                     final ConstructorGenerator constructorGenerator = new ConstructorGenerator();
                     for (final DexClassNode classNode : fileNode.clzs) {
-                        results.add(executorService.submit(() -> classVisitors.put(classNode.className, convertClass(fileNode, classNode, cvf, classes, constructorGenerator))));
+                        results.add(executorService.submit(() -> classVisitors.put(classNode.className,
+                                convertClass(fileNode, classNode, cvf, classes, constructorGenerator))));
                     }
                     executorService.submit(() -> {
                         for (Future<?> result : results) {

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -419,16 +419,16 @@ public class Dex2Asm {
         return classes;
     }
 
-    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, DexFileNode fileNode) {
-        convertClass(fileNode.dexVersion, classNode, cvf, collectClzInfo(fileNode), null);
+    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, DexFileNode fileNode, ConstructorGenerator constructorGenerator) {
+        convertClass(fileNode.dexVersion, classNode, cvf, collectClzInfo(fileNode), constructorGenerator);
     }
 
-    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf) {
-        convertClass(DexConstants.DEX_035, classNode, cvf);
+    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, ConstructorGenerator constructorGenerator) {
+        convertClass(DexConstants.DEX_035, classNode, cvf, constructorGenerator);
     }
 
-    public void convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf) {
-        convertClass(dexVersion, classNode, cvf, new HashMap<>(), null);
+    public void convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf, ConstructorGenerator constructorGenerator) {
+        convertClass(dexVersion, classNode, cvf, new HashMap<>(), constructorGenerator);
     }
 
     private static boolean isJavaIdentifier(String str) {
@@ -444,15 +444,6 @@ public class Dex2Asm {
             }
         }
         return true;
-    }
-
-    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, Map<String, Clz> classes) {
-        convertClass(DexConstants.DEX_035, classNode, cvf, classes, null);
-    }
-
-    public void convertClass(DexFileNode dfn, DexClassNode classNode, ClassVisitorFactory cvf,
-                             Map<String, Clz> classes) {
-        convertClass(dfn.dexVersion, classNode, cvf, classes, null);
     }
 
     protected ClassVisitor convertClass(DexClassNode classNode, ClassVisitorFactory cvf, Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -850,7 +850,9 @@ public class Dex2Asm {
         if ((NO_CODE_MASK & methodNode.access) == 0) { // has code
             if (methodNode.codeNode != null) {
                 mv.visitCode();
+                if (constructorGenerator != null) constructorGenerator.enterClass(classNode.className, classNode.superClass);
                 convertCode(methodNode, mv, clzCtx, constructorGenerator);
+                if (constructorGenerator != null) constructorGenerator.leaveClass();
             }
         }
 

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -9,12 +9,32 @@ import com.googlecode.d2j.Proto;
 import com.googlecode.d2j.Visibility;
 import com.googlecode.d2j.converter.Dex2IRConverter;
 import com.googlecode.d2j.converter.IR2JConverter;
-import com.googlecode.d2j.node.*;
+import com.googlecode.d2j.node.DexAnnotationNode;
+import com.googlecode.d2j.node.DexClassNode;
+import com.googlecode.d2j.node.DexCodeNode;
+import com.googlecode.d2j.node.DexFieldNode;
+import com.googlecode.d2j.node.DexFileNode;
+import com.googlecode.d2j.node.DexMethodNode;
 import com.googlecode.d2j.node.insn.MethodStmtNode;
 import com.googlecode.d2j.node.insn.Stmt0RNode;
 import com.googlecode.d2j.reader.Op;
 import com.googlecode.dex2jar.ir.IrMethod;
-import com.googlecode.dex2jar.ir.ts.*;
+import com.googlecode.dex2jar.ir.ts.AggTransformer;
+import com.googlecode.dex2jar.ir.ts.CleanLabel;
+import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
+import com.googlecode.dex2jar.ir.ts.DeadCodeTransformer;
+import com.googlecode.dex2jar.ir.ts.EndRemover;
+import com.googlecode.dex2jar.ir.ts.ExceptionHandlerTrim;
+import com.googlecode.dex2jar.ir.ts.Ir2JRegAssignTransformer;
+import com.googlecode.dex2jar.ir.ts.MultiArrayTransformer;
+import com.googlecode.dex2jar.ir.ts.NewTransformer;
+import com.googlecode.dex2jar.ir.ts.NpeTransformer;
+import com.googlecode.dex2jar.ir.ts.RemoveConstantFromSSA;
+import com.googlecode.dex2jar.ir.ts.RemoveLocalFromSSA;
+import com.googlecode.dex2jar.ir.ts.TypeTransformer;
+import com.googlecode.dex2jar.ir.ts.UnSSATransformer;
+import com.googlecode.dex2jar.ir.ts.VoidInvokeTransformer;
+import com.googlecode.dex2jar.ir.ts.ZeroTransformer;
 import com.googlecode.dex2jar.ir.ts.array.FillArrayTransformer;
 import com.googlecode.dex2jar.tools.Constants;
 import java.io.InputStream;
@@ -28,8 +48,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
-import java.util.stream.IntStream;
-
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -131,7 +149,7 @@ public class Dex2Asm {
     protected static final int ACC_INTERFACE_ABSTRACT = (Opcodes.ACC_INTERFACE | Opcodes.ACC_ABSTRACT);
 
     private static final int NO_CODE_MASK = DexConstants.ACC_ABSTRACT | DexConstants.ACC_NATIVE
-            | DexConstants.ACC_ANNOTATION;
+                                            | DexConstants.ACC_ANNOTATION;
 
     protected static final CleanLabel T_CLEAN_LABEL = new CleanLabel();
 
@@ -342,10 +360,10 @@ public class Dex2Asm {
             }
         }
         if (isSignatureNotValid(signature, false)) {
-            System.err.println("Applying workaround to method "
-                    + methodNode.method
-                    + " by removing its original signature "
-                    + signature + ".");
+            System.err.println("Applying workaround to method " +
+                               methodNode.method +
+                               " by removing its original signature " +
+                               signature + ".");
             signature = null;
         }
 
@@ -419,15 +437,18 @@ public class Dex2Asm {
         return classes;
     }
 
-    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, DexFileNode fileNode, ConstructorGenerator constructorGenerator) {
+    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, DexFileNode fileNode,
+                             ConstructorGenerator constructorGenerator) {
         convertClass(fileNode.dexVersion, classNode, cvf, collectClzInfo(fileNode), constructorGenerator);
     }
 
-    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, ConstructorGenerator constructorGenerator) {
+    public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf,
+                             ConstructorGenerator constructorGenerator) {
         convertClass(DexConstants.DEX_035, classNode, cvf, constructorGenerator);
     }
 
-    public void convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf, ConstructorGenerator constructorGenerator) {
+    public void convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf,
+                             ConstructorGenerator constructorGenerator) {
         convertClass(dexVersion, classNode, cvf, new HashMap<>(), constructorGenerator);
     }
 
@@ -446,12 +467,13 @@ public class Dex2Asm {
         return true;
     }
 
-    protected ClassVisitor convertClass(DexClassNode classNode, ClassVisitorFactory cvf, Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
+    protected ClassVisitor convertClass(DexClassNode classNode, ClassVisitorFactory cvf, Map<String, Clz> classes,
+                                        ConstructorGenerator constructorGenerator) {
         return convertClass(DexConstants.DEX_035, classNode, cvf, classes, constructorGenerator);
     }
 
     protected ClassVisitor convertClass(DexFileNode dfn, DexClassNode classNode, ClassVisitorFactory cvf,
-                             Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
+                                        Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
         return convertClass(dfn.dexVersion, classNode, cvf, classes, constructorGenerator);
     }
 
@@ -464,7 +486,7 @@ public class Dex2Asm {
     }
 
     protected ClassVisitor convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf,
-                             Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
+                                        Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
         ClassVisitor cv = cvf.create(toInternalName(classNode.className));
         if (cv == null) {
             return null;
@@ -508,10 +530,10 @@ public class Dex2Asm {
         access = clearClassAccess(isInnerClass, access);
 
         if (isSignatureNotValid(signature, false)) {
-            System.err.println("Applying workaround to class"
-                    + " " + classNode.className
-                    + " by removing its original signature "
-                    + signature + ".");
+            System.err.println("Applying workaround to class " +
+                               classNode.className +
+                               " by removing its original signature " +
+                               signature + ".");
             signature = null;
         }
 
@@ -540,8 +562,8 @@ public class Dex2Asm {
         innerClassNodes.sort(INNER_CLASS_NODE_COMPARATOR);
         for (InnerClassNode icn : innerClassNodes) {
             if (icn.innerName != null && !isJavaIdentifier(icn.innerName)) {
-                System.err.println("WARN: Ignored invalid inner-class name, "
-                        + "treat as anonymous inner class. (" + icn.innerName + ")");
+                System.err.println("WARN: Ignored invalid inner-class name, " +
+                                   "treat as anonymous inner class. (" + icn.innerName + ")");
                 icn.innerName = null;
                 icn.outerName = null;
             }
@@ -616,7 +638,8 @@ public class Dex2Asm {
         }
     }
 
-    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
+    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx,
+                            ConstructorGenerator constructorGenerator) {
         IrMethod irMethod = dex2ir(methodNode);
         optimize(irMethod, constructorGenerator);
         ir2j(irMethod, mv, clzCtx);
@@ -629,7 +652,8 @@ public class Dex2Asm {
             final Map<String, ClassVisitor> classVisitors = new HashMap<>(classes.size());
 
             for (DexClassNode classNode : fileNode.clzs) {
-                classVisitors.put(classNode.className, convertClass(fileNode, classNode, cvf, classes, constructorGenerator));
+                classVisitors.put(classNode.className, convertClass(fileNode, classNode, cvf, classes,
+                        constructorGenerator));
             }
 
             if (!constructorGenerator.isEmpty()) {
@@ -669,10 +693,10 @@ public class Dex2Asm {
         // https://github.com/pxb1988/dex2jar/issues/455
         // try validate signature before call visitField
         if (isSignatureNotValid(signature, true)) {
-            System.err.println("Applying workaround to field "
-                    + fieldNode.field
-                    + " by removing its original signature "
-                    + signature + ".");
+            System.err.println("Applying workaround to field " +
+                               fieldNode.field +
+                               " by removing its original signature " +
+                               signature + ".");
             signature = null;
         }
 
@@ -778,7 +802,8 @@ public class Dex2Asm {
         return h;
     }
 
-    public void convertMethod(DexClassNode classNode, DexMethodNode methodNode, ClassVisitor cv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
+    public void convertMethod(DexClassNode classNode, DexMethodNode methodNode, ClassVisitor cv, ClzCtx clzCtx,
+                              ConstructorGenerator constructorGenerator) {
 
         MethodVisitor mv = collectBasicMethodInfo(methodNode, cv);
 
@@ -897,8 +922,10 @@ public class Dex2Asm {
         T_IR_2_J_REG_ASSIGN.transform(irMethod);
     }
 
-    protected void insertConstructors(List<DexClassNode> classNodeList, Map<String, ClassVisitor> classes, ConstructorGenerator constructorGenerator) {
-        Map<ConstructorGenerator.ConstructorPair, DexClassNode> resolvedConstructors = new HashMap<>(classNodeList.size());
+    protected void insertConstructors(List<DexClassNode> classNodeList, Map<String, ClassVisitor> classes,
+                                      ConstructorGenerator constructorGenerator) {
+        Map<ConstructorGenerator.ConstructorPair, DexClassNode> resolvedConstructors =
+                new HashMap<>(classNodeList.size());
         for (Map.Entry<ConstructorGenerator.ConstructorPair, String> pair : constructorGenerator.entries()) {
             String owner = pair.getKey().getOwner();
             do {
@@ -907,15 +934,17 @@ public class Dex2Asm {
                         .filter(x -> x.className.equals(o))
                         .findFirst()
                         .orElseThrow(() -> new RuntimeException("No class found for constructor " + o));
-                resolvedConstructors.put(new ConstructorGenerator.ConstructorPair(owner, pair.getKey().getParameterTypes()), klass);
+                resolvedConstructors.put(new ConstructorGenerator.ConstructorPair(owner,
+                        pair.getKey().getParameterTypes()), klass);
                 owner = klass.superClass; // recursively add constructors until the desired constructor is found
             } while (!Objects.equals(owner, pair.getValue()));
         }
 
         for (Map.Entry<ConstructorGenerator.ConstructorPair, DexClassNode> pair : resolvedConstructors.entrySet()) {
-            DexClassNode klass = pair.getValue();
-            Method constructorMethod = new Method(pair.getKey().getOwner(), "<init>", pair.getKey().getParameterTypes(), "V");
-            Method superMethod = new Method(klass.superClass, "<init>", pair.getKey().getParameterTypes(), "V");
+            DexClassNode clazz = pair.getValue();
+            Method constructorMethod = new Method(pair.getKey().getOwner(), "<init>",
+                    pair.getKey().getParameterTypes(), "V");
+            Method superMethod = new Method(clazz.superClass, "<init>", pair.getKey().getParameterTypes(), "V");
             int[] callArgs = new int[pair.getKey().getParameterTypes().length + 1];
             Arrays.setAll(callArgs, i -> i);
 
@@ -925,17 +954,18 @@ public class Dex2Asm {
             constructorCode.stmts.add(superCallNode);
             Stmt0RNode returnNode = new Stmt0RNode(Op.RETURN_VOID);
             constructorCode.stmts.add(returnNode);
-            DexMethodNode newConstructor = new DexMethodNode(DexConstants.ACC_PUBLIC | DexConstants.ACC_CONSTRUCTOR, constructorMethod);
+            DexMethodNode newConstructor = new DexMethodNode(DexConstants.ACC_PUBLIC | DexConstants.ACC_CONSTRUCTOR,
+                    constructorMethod);
             newConstructor.codeNode = constructorCode;
-            if (klass.methods == null) {
-                klass.methods = new ArrayList<>();
+            if (clazz.methods == null) {
+                clazz.methods = new ArrayList<>();
             }
-            klass.methods.add(newConstructor);
+            clazz.methods.add(newConstructor);
 
-            ClassVisitor cv = classes.get(klass.className);
+            ClassVisitor cv = classes.get(clazz.className);
             ClzCtx clzCtx = new ClzCtx();
-            clzCtx.classDescriptor = klass.className;
-            convertMethod(klass, newConstructor, cv, clzCtx, null);
+            clzCtx.classDescriptor = clazz.className;
+            convertMethod(clazz, newConstructor, cv, clzCtx, null);
         }
     }
 

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -9,27 +9,12 @@ import com.googlecode.d2j.Proto;
 import com.googlecode.d2j.Visibility;
 import com.googlecode.d2j.converter.Dex2IRConverter;
 import com.googlecode.d2j.converter.IR2JConverter;
-import com.googlecode.d2j.node.DexAnnotationNode;
-import com.googlecode.d2j.node.DexClassNode;
-import com.googlecode.d2j.node.DexFieldNode;
-import com.googlecode.d2j.node.DexFileNode;
-import com.googlecode.d2j.node.DexMethodNode;
+import com.googlecode.d2j.node.*;
+import com.googlecode.d2j.node.insn.MethodStmtNode;
+import com.googlecode.d2j.node.insn.Stmt0RNode;
+import com.googlecode.d2j.reader.Op;
 import com.googlecode.dex2jar.ir.IrMethod;
-import com.googlecode.dex2jar.ir.ts.AggTransformer;
-import com.googlecode.dex2jar.ir.ts.CleanLabel;
-import com.googlecode.dex2jar.ir.ts.DeadCodeTransformer;
-import com.googlecode.dex2jar.ir.ts.EndRemover;
-import com.googlecode.dex2jar.ir.ts.ExceptionHandlerTrim;
-import com.googlecode.dex2jar.ir.ts.Ir2JRegAssignTransformer;
-import com.googlecode.dex2jar.ir.ts.MultiArrayTransformer;
-import com.googlecode.dex2jar.ir.ts.NewTransformer;
-import com.googlecode.dex2jar.ir.ts.NpeTransformer;
-import com.googlecode.dex2jar.ir.ts.RemoveConstantFromSSA;
-import com.googlecode.dex2jar.ir.ts.RemoveLocalFromSSA;
-import com.googlecode.dex2jar.ir.ts.TypeTransformer;
-import com.googlecode.dex2jar.ir.ts.UnSSATransformer;
-import com.googlecode.dex2jar.ir.ts.VoidInvokeTransformer;
-import com.googlecode.dex2jar.ir.ts.ZeroTransformer;
+import com.googlecode.dex2jar.ir.ts.*;
 import com.googlecode.dex2jar.ir.ts.array.FillArrayTransformer;
 import com.googlecode.dex2jar.tools.Constants;
 import java.io.InputStream;
@@ -43,6 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
+import java.util.stream.IntStream;
+
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -433,7 +420,7 @@ public class Dex2Asm {
     }
 
     public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, DexFileNode fileNode) {
-        convertClass(fileNode.dexVersion, classNode, cvf, collectClzInfo(fileNode));
+        convertClass(fileNode.dexVersion, classNode, cvf, collectClzInfo(fileNode), null);
     }
 
     public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf) {
@@ -441,7 +428,7 @@ public class Dex2Asm {
     }
 
     public void convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf) {
-        convertClass(dexVersion, classNode, cvf, new HashMap<>());
+        convertClass(dexVersion, classNode, cvf, new HashMap<>(), null);
     }
 
     private static boolean isJavaIdentifier(String str) {
@@ -460,19 +447,36 @@ public class Dex2Asm {
     }
 
     public void convertClass(DexClassNode classNode, ClassVisitorFactory cvf, Map<String, Clz> classes) {
-        convertClass(DexConstants.DEX_035, classNode, cvf, classes);
+        convertClass(DexConstants.DEX_035, classNode, cvf, classes, null);
     }
 
     public void convertClass(DexFileNode dfn, DexClassNode classNode, ClassVisitorFactory cvf,
                              Map<String, Clz> classes) {
-        convertClass(dfn.dexVersion, classNode, cvf, classes);
+        convertClass(dfn.dexVersion, classNode, cvf, classes, null);
+    }
+
+    protected ClassVisitor convertClass(DexClassNode classNode, ClassVisitorFactory cvf, Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
+        return convertClass(DexConstants.DEX_035, classNode, cvf, classes, constructorGenerator);
+    }
+
+    protected ClassVisitor convertClass(DexFileNode dfn, DexClassNode classNode, ClassVisitorFactory cvf,
+                             Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
+        return convertClass(dfn.dexVersion, classNode, cvf, classes, constructorGenerator);
     }
 
     public void convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf,
                              Map<String, Clz> classes) {
+        ClassVisitor cv = convertClass(dexVersion, classNode, cvf, classes, null);
+        if (cv != null) {
+            cv.visitEnd();
+        }
+    }
+
+    protected ClassVisitor convertClass(int dexVersion, DexClassNode classNode, ClassVisitorFactory cvf,
+                             Map<String, Clz> classes, ConstructorGenerator constructorGenerator) {
         ClassVisitor cv = cvf.create(toInternalName(classNode.className));
         if (cv == null) {
-            return;
+            return null;
         }
         // the default value of static-final field are omitted by dex, fix it
         DexFix.fixStaticFinalFieldValue(classNode);
@@ -565,14 +569,14 @@ public class Dex2Asm {
             clzCtx.classDescriptor = classNode.className;
             for (DexMethodNode methodNode : classNode.methods) {
                 DexFix.fixTooLongStringConstant(methodNode);
-                convertMethod(classNode, methodNode, cv, clzCtx);
+                convertMethod(classNode, methodNode, cv, clzCtx, constructorGenerator);
             }
             if (clzCtx.hexDecodeMethodNamePrefix != null) {
                 addHexDecodeMethod(cv, classNode.className.replaceFirst("^L", "").replaceAll(";$", ""),
                         clzCtx.hexDecodeMethodNamePrefix);
             }
         }
-        cv.visitEnd();
+        return cv;
     }
 
     private static final String HEX_CLASS_LOCATION = "res/Hex";
@@ -621,17 +625,28 @@ public class Dex2Asm {
         }
     }
 
-    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx) {
+    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
         IrMethod irMethod = dex2ir(methodNode);
-        optimize(irMethod);
+        optimize(irMethod, constructorGenerator);
         ir2j(irMethod, mv, clzCtx);
     }
 
     public void convertDex(DexFileNode fileNode, ClassVisitorFactory cvf) {
         if (fileNode.clzs != null) {
-            Map<String, Clz> classes = collectClzInfo(fileNode);
+            final Map<String, Clz> classes = collectClzInfo(fileNode);
+            final ConstructorGenerator constructorGenerator = new ConstructorGenerator();
+            final Map<String, ClassVisitor> classVisitors = new HashMap<>(classes.size());
+
             for (DexClassNode classNode : fileNode.clzs) {
-                convertClass(fileNode, classNode, cvf, classes);
+                classVisitors.put(classNode.className, convertClass(fileNode, classNode, cvf, classes, constructorGenerator));
+            }
+
+            if (!constructorGenerator.isEmpty()) {
+                insertConstructors(fileNode.clzs, classVisitors, constructorGenerator);
+            }
+
+            for (ClassVisitor cv : classVisitors.values()) {
+                cv.visitEnd();
             }
         }
     }
@@ -772,7 +787,7 @@ public class Dex2Asm {
         return h;
     }
 
-    public void convertMethod(DexClassNode classNode, DexMethodNode methodNode, ClassVisitor cv, ClzCtx clzCtx) {
+    public void convertMethod(DexClassNode classNode, DexMethodNode methodNode, ClassVisitor cv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
 
         MethodVisitor mv = collectBasicMethodInfo(methodNode, cv);
 
@@ -819,7 +834,7 @@ public class Dex2Asm {
         if ((NO_CODE_MASK & methodNode.access) == 0) { // has code
             if (methodNode.codeNode != null) {
                 mv.visitCode();
-                convertCode(methodNode, mv, clzCtx);
+                convertCode(methodNode, mv, clzCtx, constructorGenerator);
             }
         }
 
@@ -860,7 +875,7 @@ public class Dex2Asm {
         mv.visitMaxs(-1, -1);
     }
 
-    public void optimize(IrMethod irMethod) {
+    public void optimize(IrMethod irMethod, ConstructorGenerator constructorGenerator) {
         T_CLEAN_LABEL.transform(irMethod);
         T_DEAD_CODE.transform(irMethod);
         T_REMOVE_LOCAL.transform(irMethod);
@@ -871,7 +886,7 @@ public class Dex2Asm {
             T_REMOVE_LOCAL.transform(irMethod);
             T_REMOVE_CONST.transform(irMethod);
         }
-        T_NEW.transform(irMethod);
+        T_NEW.transform(irMethod, constructorGenerator);
         T_FILL_ARRAY.transform(irMethod);
         T_AGG.transform(irMethod);
         T_MULTI_ARRAY.transform(irMethod);
@@ -889,6 +904,38 @@ public class Dex2Asm {
         T_UNSSA.transform(irMethod);
         T_TRIM_EX.transform(irMethod);
         T_IR_2_J_REG_ASSIGN.transform(irMethod);
+    }
+
+    protected void insertConstructors(List<DexClassNode> classNodeList, Map<String, ClassVisitor> classes, ConstructorGenerator constructorGenerator) {
+        for (Map.Entry<ConstructorGenerator.ConstructorPair, String> pair : constructorGenerator.entries()) {
+            DexClassNode klass = classNodeList.stream()
+                    .filter(x -> x.className.equals(pair.getKey().getOwner()))
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException("No class found for constructor " + pair.getKey().getOwner()));
+
+            Method constructorMethod = new Method(pair.getKey().getOwner(), "<init>", pair.getKey().getParameterTypes(), "V");
+            Method superMethod = new Method(pair.getValue(), "<init>", pair.getKey().getParameterTypes(), "V");
+            int[] callArgs = new int[pair.getKey().getParameterTypes().length + 1];
+            Arrays.setAll(callArgs, i -> i);
+
+            DexCodeNode constructorCode = new DexCodeNode();
+            constructorCode.totalRegister = callArgs.length;
+            MethodStmtNode superCallNode = new MethodStmtNode(Op.INVOKE_DIRECT, callArgs, superMethod);
+            constructorCode.stmts.add(superCallNode);
+            Stmt0RNode returnNode = new Stmt0RNode(Op.RETURN_VOID);
+            constructorCode.stmts.add(returnNode);
+            DexMethodNode newConstructor = new DexMethodNode(DexConstants.ACC_PUBLIC | DexConstants.ACC_CONSTRUCTOR, constructorMethod);
+            newConstructor.codeNode = constructorCode;
+            if (klass.methods == null) {
+                klass.methods = new ArrayList<>();
+            }
+            klass.methods.add(newConstructor);
+
+            ClassVisitor cv = classes.get(klass.className);
+            ClzCtx clzCtx = new ClzCtx();
+            clzCtx.classDescriptor = klass.className;
+            convertMethod(klass, newConstructor, cv, clzCtx, null);
+        }
     }
 
     /**

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -907,14 +907,24 @@ public class Dex2Asm {
     }
 
     protected void insertConstructors(List<DexClassNode> classNodeList, Map<String, ClassVisitor> classes, ConstructorGenerator constructorGenerator) {
+        Map<ConstructorGenerator.ConstructorPair, DexClassNode> resolvedConstructors = new HashMap<>(classNodeList.size());
         for (Map.Entry<ConstructorGenerator.ConstructorPair, String> pair : constructorGenerator.entries()) {
-            DexClassNode klass = classNodeList.stream()
-                    .filter(x -> x.className.equals(pair.getKey().getOwner()))
-                    .findFirst()
-                    .orElseThrow(() -> new RuntimeException("No class found for constructor " + pair.getKey().getOwner()));
+            String owner = pair.getKey().getOwner();
+            do {
+                final String o = owner;
+                DexClassNode klass = classNodeList.stream()
+                        .filter(x -> x.className.equals(o))
+                        .findFirst()
+                        .orElseThrow(() -> new RuntimeException("No class found for constructor " + o));
+                resolvedConstructors.put(new ConstructorGenerator.ConstructorPair(owner, pair.getKey().getParameterTypes()), klass);
+                owner = klass.superClass; // recursively add constructors until the desired constructor is found
+            } while (!Objects.equals(owner, pair.getValue()));
+        }
 
+        for (Map.Entry<ConstructorGenerator.ConstructorPair, DexClassNode> pair : resolvedConstructors.entrySet()) {
+            DexClassNode klass = pair.getValue();
             Method constructorMethod = new Method(pair.getKey().getOwner(), "<init>", pair.getKey().getParameterTypes(), "V");
-            Method superMethod = new Method(pair.getValue(), "<init>", pair.getKey().getParameterTypes(), "V");
+            Method superMethod = new Method(klass.superClass, "<init>", pair.getKey().getParameterTypes(), "V");
             int[] callArgs = new int[pair.getKey().getParameterTypes().length + 1];
             Arrays.setAll(callArgs, i -> i);
 

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
@@ -167,7 +167,8 @@ public final class Dex2jar {
 
         new ExDex2Asm(exceptionHandler) {
             @Override
-            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
+            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx,
+                                    ConstructorGenerator constructorGenerator) {
                 if ((readerConfig & DexFileReader.SKIP_CODE) != 0 && methodNode.method.getName().equals("<clinit>")) {
                     // also skip clinit
                     return;

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
@@ -9,6 +9,7 @@ import com.googlecode.d2j.reader.MultiDexFileReader;
 import com.googlecode.dex2jar.ir.IrMethod;
 import com.googlecode.dex2jar.ir.stmt.LabelStmt;
 import com.googlecode.dex2jar.ir.stmt.Stmt;
+import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
 import com.googlecode.dex2jar.tools.Constants;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -165,16 +166,17 @@ public final class Dex2jar {
         };
 
         new ExDex2Asm(exceptionHandler) {
-            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx) {
+            @Override
+            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
                 if ((readerConfig & DexFileReader.SKIP_CODE) != 0 && methodNode.method.getName().equals("<clinit>")) {
                     // also skip clinit
                     return;
                 }
-                super.convertCode(methodNode, mv, clzCtx);
+                super.convertCode(methodNode, mv, clzCtx, constructorGenerator);
             }
 
             @Override
-            public void optimize(IrMethod irMethod) {
+            public void optimize(IrMethod irMethod, ConstructorGenerator constructorGenerator) {
                 T_CLEAN_LABEL.transform(irMethod);
                 /*if (0 != (v3Config & V3.TOPOLOGICAL_SORT)) {
                     // T_topologicalSort.transform(irMethod);
@@ -188,7 +190,7 @@ public final class Dex2jar {
                     T_REMOVE_LOCAL.transform(irMethod);
                     T_REMOVE_CONST.transform(irMethod);
                 }
-                T_NEW.transform(irMethod);
+                T_NEW.transform(irMethod, constructorGenerator);
                 T_FILL_ARRAY.transform(irMethod);
                 T_AGG.transform(irMethod);
                 T_MULTI_ARRAY.transform(irMethod);

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/ExDex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/ExDex2Asm.java
@@ -17,7 +17,8 @@ public class ExDex2Asm extends Dex2Asm {
     }
 
     @Override
-    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
+    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx,
+                            ConstructorGenerator constructorGenerator) {
         MethodVisitor mw = AsmBridge.searchMethodWriter(mv);
         MethodNode mn = new MethodNode(Constants.ASM_VERSION, methodNode.access, methodNode.method.getName(),
                 methodNode.method.getDesc(), null, null);

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/ExDex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/ExDex2Asm.java
@@ -2,6 +2,7 @@ package com.googlecode.d2j.dex;
 
 import com.googlecode.d2j.DexException;
 import com.googlecode.d2j.node.DexMethodNode;
+import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
 import com.googlecode.dex2jar.tools.Constants;
 import org.objectweb.asm.AsmBridge;
 import org.objectweb.asm.MethodVisitor;
@@ -16,12 +17,12 @@ public class ExDex2Asm extends Dex2Asm {
     }
 
     @Override
-    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx) {
+    public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
         MethodVisitor mw = AsmBridge.searchMethodWriter(mv);
         MethodNode mn = new MethodNode(Constants.ASM_VERSION, methodNode.access, methodNode.method.getName(),
                 methodNode.method.getDesc(), null, null);
         try {
-            super.convertCode(methodNode, mn, clzCtx);
+            super.convertCode(methodNode, mn, clzCtx, constructorGenerator);
         } catch (Exception ex) {
             if (exceptionHandler == null) {
                 new DexException(ex, "Failed to convert code for %s", methodNode.method)

--- a/dex-translator/src/test/java/com/googlecode/dex2jar/test/TestUtils.java
+++ b/dex-translator/src/test/java/com/googlecode/dex2jar/test/TestUtils.java
@@ -275,7 +275,8 @@ public abstract class TestUtils {
         // 1. convert to .class
         Dex2Asm dex2Asm = new Dex2Asm() {
             @Override
-            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
+            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx,
+                                    ConstructorGenerator constructorGenerator) {
                 try {
                     super.convertCode(methodNode, mv, clzCtx, constructorGenerator);
                 } catch (Exception ex) {

--- a/dex-translator/src/test/java/com/googlecode/dex2jar/test/TestUtils.java
+++ b/dex-translator/src/test/java/com/googlecode/dex2jar/test/TestUtils.java
@@ -19,6 +19,7 @@ import com.googlecode.d2j.node.DexMethodNode;
 import com.googlecode.d2j.reader.zip.ZipUtil;
 import com.googlecode.d2j.smali.BaksmaliDumper;
 import com.googlecode.d2j.visitors.DexClassVisitor;
+import com.googlecode.dex2jar.ir.ts.ConstructorGenerator;
 import com.googlecode.dex2jar.tools.Constants;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -274,9 +275,9 @@ public abstract class TestUtils {
         // 1. convert to .class
         Dex2Asm dex2Asm = new Dex2Asm() {
             @Override
-            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx) {
+            public void convertCode(DexMethodNode methodNode, MethodVisitor mv, ClzCtx clzCtx, ConstructorGenerator constructorGenerator) {
                 try {
-                    super.convertCode(methodNode, mv, clzCtx);
+                    super.convertCode(methodNode, mv, clzCtx, constructorGenerator);
                 } catch (Exception ex) {
                     BaksmaliDumper d = new BaksmaliDumper();
                     try {
@@ -295,9 +296,9 @@ public abstract class TestUtils {
         final LambadaNameSafeClassAdapter rca = new LambadaNameSafeClassAdapter(cw, false);
         ClassVisitorFactory cvf = classInternalName -> rca;
         if (fileNode != null) {
-            dex2Asm.convertClass(clzNode, cvf, fileNode);
+            dex2Asm.convertClass(clzNode, cvf, fileNode, null);
         } else {
-            dex2Asm.convertClass(clzNode, cvf);
+            dex2Asm.convertClass(clzNode, cvf, null);
         }
         byte[] data = cw.toByteArray();
 


### PR DESCRIPTION
We may have byte code like this:

```
006a5c: 2200 2900                              |0000: new-instance v0, LTestClass; // type@0029
006a60: 1a01 2803                              |0002: const-string v1, "en" // string@0328
006a64: 7030 5900 1001                         |0004: invoke-direct {v0, v1, v1}, LTestBase;.<init>:(Ljava/lang/String;Ljava/lang/String;)V // method@0059
```

Previously, this was translated to a call to `new TestBase("en", "en")`,
instead of `new TestClass("en", "en")` (where `TestClass extends
TestBase`).

See a reproduction in https://github.com/cpiber/dex2jar-repro. With `minifyEnable = true`, proguard will optimize away both the `TestClass` constructor, as well as the `TestBase` constructor. It will directly invoke the `Object` constructor from the `TestFactor.create` method, which is not valid in Java, so we need to generate the missing constructors as pass-through and call the generated constructor instead of the direct invocation.