### PR TITLE
DexFix: Fix off-by-one in string correction

### DIFF
--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/DexFix.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/DexFix.java
@@ -193,7 +193,7 @@ public final class DexFix {
                     generatedStringConcat.add(new Stmt1RNode(Op.MOVE_RESULT_OBJECT, register));
 
                     toBeReplaced.put(insn, generatedStringConcat);
-                    maxRegister.set(Math.max(register + 1, maxRegister.get()));
+                    maxRegister.set(Math.max(register + 2, maxRegister.get()));
                 }
             });
 


### PR DESCRIPTION
`codeNode.totalRegister` counts how many registers are used, e.g. `1`. So since we want to use `register + 1`, we need to claim `register + 2` values (so `register + 1` is a valid index later in DMV conversion). `maxRegister` is perhaps the wrong name for what it is doing.