### PR TITLE
fix: Correct base class

### DIFF
--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2jar.java
@@ -116,7 +116,7 @@ public final class Dex2jar {
                             return super.getCommonSuperClass(type1, type2);
                         } catch (Throwable t) {
                             // If all else fails
-                            return "java/util/Object";
+                            return "java/lang/Object";
                         }
                     }
                 };


### PR DESCRIPTION
Java has no `java.util.Object`, only `java.lang.Object` (the base class for all classes, so likely intended here) and `java.util.Objects` (static helper methods)